### PR TITLE
Implement RSS and Atom generation

### DIFF
--- a/hstp/reader.py
+++ b/hstp/reader.py
@@ -5,6 +5,8 @@ import os
 import json
 from shutil import copyfile
 
+from feedgen.feed import FeedGenerator
+
 
 class Reader:
     """ Read in an input tree to a station object """
@@ -57,6 +59,14 @@ class Reader:
         hstp_out = dict()
         hstp_out['podcasts'] = []
         for p in self.podcasts:
+            podcast_rss = FeedGenerator()
+
+            podcast_rss.id(p.slug)
+            podcast_rss.title(p.name)
+            podcast_rss.subtitle(p.description)
+            podcast_rss.description(p.description)
+            podcast_rss.link({"href": "https://example.org/", "rel": "alternate"})
+
             hstp_out['podcasts'].append(p.dump(False))
             with open(f"{output_path}/{p.slug}.json", 'w') as f:
                 f.write(json.dumps(p.dump(True)))
@@ -70,6 +80,17 @@ class Reader:
                 copyfile(e.file, f"{output_path}/{p.slug}/{e.slug}.mp3")
                 if e.thumb is not None:
                     copyfile(e.thumb, f"{output_path}/{p.slug}/{e.slug}.jpg")
+
+                entry = podcast_rss.add_entry()
+
+                entry.id(e.slug)
+                entry.title(e.name)
+                entry.description(e.description)
+                entry.published(e.date)
+                entry.link({"href": "https://example.org/", "rel": "alternate"})
+
+            podcast_rss.atom_file(f"{output_path}/{p.slug}.atom.xml")
+            podcast_rss.rss_file(f"{output_path}/{p.slug}.rss.xml")
 
         hstp_out['podcasts'].sort(key=lambda x: x['last-updated'])
         hstp_out['podcasts'].reverse()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pycodestyle==2.7.0
 requests==2.26.0
 python-dateutil==2.8.2
 simple-colors==0.1.5
+feedgen==0.9.0


### PR DESCRIPTION
This PR generates an RSS and Atom feed for each given podcast. It's marked as a draft for now so that we can go through some implementation details tomorrow.

# Implementation

This PR adds the feedgen dependency and then creates and saves a new RSS & Atom feed for each podcast when the HSTP inventory is built (this will require specification updates to show that a feed is generated and placed in the root).

Due to RSS requirements this PR **makes descriptions mandatory on podcasts and episodes**.

# Questions

- We need public URLs for the feeds, one for each episode (though this could just be a link to the podcast page).
  - How do we want to do this? Should we add some sort of configuration to the import format that allows the HSTP builder to generate the production URLs?
  - As of now, feeds are generated with example.org.
- Should we have one feed per podcast or one for the whole inventory? (we can easily do both as well, we can just add the generated entry to a root feed and a per-podcast feed).
- We should ideally also have a way for the feed to refer to itself (with a `rel=self` link entry). This is another thing that needs configuring.
- What properties are required by external platforms for podcast ingest? If we want to be able to hand off generated inventories to something like Spotify/Anchor/etc. we should check we implement all the necessary keys.